### PR TITLE
Add expose-route to web-ui

### DIFF
--- a/helm-chart/templates/web-ui-deploy.yaml
+++ b/helm-chart/templates/web-ui-deploy.yaml
@@ -75,6 +75,7 @@ spec:
         sidecar.istio.io/inject: "true"
       labels:
         epc-mode: webui
+        maistra.io/expose-route: 'true'
     spec:    
       serviceAccountName: 5gcore
       containers:


### PR DESCRIPTION
In order to expose webui as OCP route, label to allow networkpolicy is needed